### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/src/main/java/org/apache/log4j/EnhancedThrowableRenderer.java
+++ b/src/main/java/org/apache/log4j/EnhancedThrowableRenderer.java
@@ -84,7 +84,7 @@ public final class EnhancedThrowableRenderer implements ThrowableRenderer {
      * @return string representation of element.
      */
     private String formatElement(final Object element, final Map classMap) {
-	StringBuffer buf = new StringBuffer("\tat ");
+	StringBuilder buf = new StringBuilder("\tat ");
 	buf.append(element);
 	try {
 	    String className = getClassNameMethod.invoke(element, (Object[]) null).toString();

--- a/src/main/java/org/apache/log4j/HTMLLayout.java
+++ b/src/main/java/org/apache/log4j/HTMLLayout.java
@@ -207,7 +207,7 @@ public class HTMLLayout extends Layout {
      * Returns appropriate HTML headers.
      */
     public String getHeader() {
-	StringBuffer sbuf = new StringBuffer();
+	StringBuilder sbuf = new StringBuilder();
 	sbuf.append(
 		"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
 			+ Layout.LINE_SEP);
@@ -244,7 +244,7 @@ public class HTMLLayout extends Layout {
      * Returns the appropriate HTML footers.
      */
     public String getFooter() {
-	StringBuffer sbuf = new StringBuffer();
+	StringBuilder sbuf = new StringBuilder();
 	sbuf.append("</table>" + Layout.LINE_SEP);
 	sbuf.append("<br>" + Layout.LINE_SEP);
 	sbuf.append("</body></html>");

--- a/src/main/java/org/apache/log4j/chainsaw/DetailPanel.java
+++ b/src/main/java/org/apache/log4j/chainsaw/DetailPanel.java
@@ -107,7 +107,7 @@ class DetailPanel extends JPanel implements ListSelectionListener {
 	    return null;
 	}
 
-	final StringBuffer sb = new StringBuffer();
+	final StringBuilder sb = new StringBuilder();
 	for (int i = 0; i < strs.length; i++) {
 	    sb.append(strs[i]).append("\n");
 	}
@@ -127,7 +127,7 @@ class DetailPanel extends JPanel implements ListSelectionListener {
 	    return null;
 	}
 
-	final StringBuffer buf = new StringBuffer();
+	final StringBuilder buf = new StringBuilder();
 	for (int i = 0; i < aStr.length(); i++) {
 	    char c = aStr.charAt(i);
 	    switch (c) {

--- a/src/main/java/org/apache/log4j/chainsaw/LoadXMLAction.java
+++ b/src/main/java/org/apache/log4j/chainsaw/LoadXMLAction.java
@@ -107,7 +107,7 @@ class LoadXMLAction extends AbstractAction {
     private int loadFile(String aFile) throws SAXException, IOException {
 	synchronized (mParser) {
 	    // Create a dummy document to parse the file
-	    final StringBuffer buf = new StringBuffer();
+	    final StringBuilder buf = new StringBuilder();
 	    buf.append("<?xml version=\"1.0\" standalone=\"yes\"?>\n");
 	    buf.append("<!DOCTYPE log4j:eventSet ");
 	    buf.append("[<!ENTITY data SYSTEM \"file:///");

--- a/src/main/java/org/apache/log4j/config/PropertyPrinter.java
+++ b/src/main/java/org/apache/log4j/config/PropertyPrinter.java
@@ -146,7 +146,7 @@ public class PropertyPrinter implements PropertyGetter.PropertyCallback {
     public static String capitalize(String name) {
 	if (Character.isLowerCase(name.charAt(0))) {
 	    if (name.length() == 1 || Character.isLowerCase(name.charAt(1))) {
-		StringBuffer newname = new StringBuffer(name);
+		StringBuilder newname = new StringBuilder(name);
 		newname.setCharAt(0, Character.toUpperCase(name.charAt(0)));
 		return newname.toString();
 	    }

--- a/src/main/java/org/apache/log4j/helpers/OptionConverter.java
+++ b/src/main/java/org/apache/log4j/helpers/OptionConverter.java
@@ -62,7 +62,7 @@ public class OptionConverter {
     public static String convertSpecialChars(String s) {
 	char c;
 	int len = s.length();
-	StringBuffer sbuf = new StringBuffer(len);
+	StringBuilder sbuf = new StringBuilder(len);
 
 	int i = 0;
 	while (i < len) {
@@ -371,7 +371,7 @@ public class OptionConverter {
      */
     public static String substVars(String val, Properties props) throws IllegalArgumentException {
 
-	StringBuffer sbuf = new StringBuffer();
+	StringBuilder sbuf = new StringBuilder();
 
 	int i = 0;
 	int j, k;

--- a/src/main/java/org/apache/log4j/helpers/PatternParser.java
+++ b/src/main/java/org/apache/log4j/helpers/PatternParser.java
@@ -426,7 +426,7 @@ public class PatternParser {
 
 	public String convert(LoggingEvent event) {
 	    if (key == null) {
-		StringBuffer buf = new StringBuffer("{");
+		StringBuilder buf = new StringBuilder("{");
 		Map properties = event.getProperties();
 		if (properties.size() > 0) {
 		    Object[] keys = properties.keySet().toArray();

--- a/src/main/java/org/apache/log4j/helpers/Transform.java
+++ b/src/main/java/org/apache/log4j/helpers/Transform.java
@@ -48,10 +48,10 @@ public class Transform {
 	    return input;
 	}
 
-	// Use a StringBuffer in lieu of String concatenation -- it is
+	// Use a StringBuilder in lieu of String concatenation -- it is
 	// much more efficient this way.
 
-	StringBuffer buf = new StringBuffer(input.length() + 6);
+	StringBuilder buf = new StringBuilder(input.length() + 6);
 	char ch = ' ';
 
 	int len = input.length();

--- a/src/main/java/org/apache/log4j/net/SMTPAppender.java
+++ b/src/main/java/org/apache/log4j/net/SMTPAppender.java
@@ -351,7 +351,7 @@ public class SMTPAppender extends AppenderSkeleton implements UnrecognizedElemen
 	// Note: this code already owns the monitor for this
 	// appender. This frees us from needing to synchronize on 'cb'.
 
-	StringBuffer sbuf = new StringBuffer();
+	StringBuilder sbuf = new StringBuilder();
 	String t = layout.getHeader();
 	if (t != null)
 	    sbuf.append(t);
@@ -404,7 +404,7 @@ public class SMTPAppender extends AppenderSkeleton implements UnrecognizedElemen
 		    headers.setHeader("Content-Transfer-Encoding", "quoted-printable");
 		    part = new MimeBodyPart(headers, os.toByteArray());
 		} catch (Exception ex) {
-		    StringBuffer sbuf = new StringBuffer(s);
+			StringBuilder sbuf = new StringBuilder(s);
 		    for (int i = 0; i < sbuf.length(); i++) {
 			if (sbuf.charAt(i) >= 0x80) {
 			    sbuf.setCharAt(i, '?');

--- a/src/main/java/org/apache/log4j/net/SyslogAppender.java
+++ b/src/main/java/org/apache/log4j/net/SyslogAppender.java
@@ -330,7 +330,7 @@ public class SyslogAppender extends AppenderSkeleton {
 	    packet = layout.format(event);
 	}
 	if (facilityPrinting || hdr.length() > 0) {
-	    StringBuffer buf = new StringBuffer(hdr);
+	    StringBuilder buf = new StringBuilder(hdr);
 	    if (facilityPrinting) {
 		buf.append(facilityStr);
 	    }
@@ -508,7 +508,7 @@ public class SyslogAppender extends AppenderSkeleton {
      */
     private String getPacketHeader(final long timeStamp) {
 	if (header) {
-	    StringBuffer buf = new StringBuffer(dateFormat.format(new Date(timeStamp)));
+	    StringBuilder buf = new StringBuilder(dateFormat.format(new Date(timeStamp)));
 	    // RFC 3164 says leading space, not leading zero on days 1-9
 	    if (buf.charAt(4) == '0') {
 		buf.setCharAt(4, ' ');
@@ -530,7 +530,7 @@ public class SyslogAppender extends AppenderSkeleton {
 	    String packet = msg;
 	    String hdr = getPacketHeader(new Date().getTime());
 	    if (facilityPrinting || hdr.length() > 0) {
-		StringBuffer buf = new StringBuffer(hdr);
+		StringBuilder buf = new StringBuilder(hdr);
 		if (facilityPrinting) {
 		    buf.append(facilityStr);
 		}

--- a/src/main/java/org/apache/log4j/net/TelnetAppender.java
+++ b/src/main/java/org/apache/log4j/net/TelnetAppender.java
@@ -121,7 +121,7 @@ public class TelnetAppender extends AppenderSkeleton {
 	    if (layout.ignoresThrowable()) {
 		String[] s = event.getThrowableStrRep();
 		if (s != null) {
-		    StringBuffer buf = new StringBuffer();
+		    StringBuilder buf = new StringBuilder();
 		    for (int i = 0; i < s.length; i++) {
 			buf.append(s[i]);
 			buf.append("\r\n");

--- a/src/main/java/org/apache/log4j/or/ThreadGroupRenderer.java
+++ b/src/main/java/org/apache/log4j/or/ThreadGroupRenderer.java
@@ -50,7 +50,7 @@ public class ThreadGroupRenderer implements ObjectRenderer {
      */
     public String doRender(Object o) {
 	if (o instanceof ThreadGroup) {
-	    StringBuffer sbuf = new StringBuffer();
+	    StringBuilder sbuf = new StringBuilder();
 	    ThreadGroup tg = (ThreadGroup) o;
 	    sbuf.append("java.lang.ThreadGroup[name=");
 	    sbuf.append(tg.getName());

--- a/src/main/java/org/apache/log4j/or/jms/MessageRenderer.java
+++ b/src/main/java/org/apache/log4j/or/jms/MessageRenderer.java
@@ -40,7 +40,7 @@ public class MessageRenderer implements ObjectRenderer {
      */
     public String doRender(Object o) {
 	if (o instanceof Message) {
-	    StringBuffer sbuf = new StringBuffer();
+	    StringBuilder sbuf = new StringBuilder();
 	    Message m = (Message) o;
 	    try {
 		sbuf.append("DeliveryMode=");

--- a/src/main/java/org/apache/log4j/or/sax/AttributesRenderer.java
+++ b/src/main/java/org/apache/log4j/or/sax/AttributesRenderer.java
@@ -37,7 +37,7 @@ public class AttributesRenderer implements ObjectRenderer {
      */
     public String doRender(Object o) {
 	if (o instanceof Attributes) {
-	    StringBuffer sbuf = new StringBuffer();
+	    StringBuilder sbuf = new StringBuilder();
 	    Attributes a = (Attributes) o;
 	    int len = a.getLength();
 	    boolean first = true;

--- a/src/main/java/org/apache/log4j/pattern/PatternParser.java
+++ b/src/main/java/org/apache/log4j/pattern/PatternParser.java
@@ -188,8 +188,8 @@ public final class PatternParser {
      *                       unrecognized.
      * @return position in pattern after converter.
      */
-    private static int extractConverter(char lastChar, final String pattern, int i, final StringBuffer convBuf,
-	    final StringBuffer currentLiteral) {
+    private static int extractConverter(char lastChar, final String pattern, int i, final StringBuilder convBuf,
+	    final StringBuilder currentLiteral) {
 	convBuf.setLength(0);
 
 	// When this method is called, lastChar points to the first character of the
@@ -256,7 +256,7 @@ public final class PatternParser {
 	    throw new NullPointerException("pattern");
 	}
 
-	StringBuffer currentLiteral = new StringBuffer(32);
+	StringBuilder currentLiteral = new StringBuilder(32);
 
 	int patternLength = pattern.length();
 	int state = LITERAL_STATE;
@@ -412,7 +412,7 @@ public final class PatternParser {
      * @param options           converter options.
      * @return converter or null.
      */
-    private static PatternConverter createConverter(final String converterId, final StringBuffer currentLiteral,
+    private static PatternConverter createConverter(final String converterId, final StringBuilder currentLiteral,
 	    final Map converterRegistry, final Map rules, final List options) {
 	String converterName = converterId;
 	Object converterObj = null;
@@ -504,10 +504,10 @@ public final class PatternParser {
      * @param formattingInfos   list to receive corresponding field specifier.
      * @return position after format specifier sequence.
      */
-    private static int finalizeConverter(char c, String pattern, int i, final StringBuffer currentLiteral,
+    private static int finalizeConverter(char c, String pattern, int i, final StringBuilder currentLiteral,
 	    final FormattingInfo formattingInfo, final Map converterRegistry, final Map rules,
 	    final List patternConverters, final List formattingInfos) {
-	StringBuffer convBuf = new StringBuffer();
+	StringBuilder convBuf = new StringBuilder();
 	i = extractConverter(c, pattern, i, convBuf, currentLiteral);
 
 	String converterId = convBuf.toString();
@@ -518,12 +518,12 @@ public final class PatternParser {
 	PatternConverter pc = createConverter(converterId, currentLiteral, converterRegistry, rules, options);
 
 	if (pc == null) {
-	    StringBuffer msg;
+	    StringBuilder msg;
 
 	    if ((converterId == null) || (converterId.length() == 0)) {
-		msg = new StringBuffer("Empty conversion specifier starting at position ");
+		msg = new StringBuilder("Empty conversion specifier starting at position ");
 	    } else {
-		msg = new StringBuffer("Unrecognized conversion specifier [");
+		msg = new StringBuilder("Unrecognized conversion specifier [");
 		msg.append(converterId);
 		msg.append("] starting at position ");
 	    }

--- a/src/main/java/org/apache/log4j/spi/LocationInfo.java
+++ b/src/main/java/org/apache/log4j/spi/LocationInfo.java
@@ -114,7 +114,7 @@ public class LocationInfo implements java.io.Serializable {
 			} else {
 			    lineNumber = Integer.toString(line);
 			}
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(className);
 			buf.append(".");
 			buf.append(methodName);
@@ -144,7 +144,7 @@ public class LocationInfo implements java.io.Serializable {
      *                 value of NA will be appended.
      * @since 1.2.15
      */
-    private static final void appendFragment(final StringBuffer buf, final String fragment) {
+    private static final void appendFragment(final StringBuilder buf, final String fragment) {
 	if (fragment == null) {
 	    buf.append(NA);
 	} else {
@@ -167,7 +167,7 @@ public class LocationInfo implements java.io.Serializable {
 	this.className = classname;
 	this.methodName = method;
 	this.lineNumber = line;
-	StringBuffer buf = new StringBuffer();
+	StringBuilder buf = new StringBuilder();
 	appendFragment(buf, classname);
 	buf.append(".");
 	appendFragment(buf, method);


### PR DESCRIPTION
Reload is setting a minimum java version to 1.5, so we can replace StringBuffer with StringBuilder for some performance gain.

This Pull Request only changes the safe cases: variables privates to a method or used only in private methods calls.

Only changed src/main code, not src/test
