### PR TITLE
Added automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
             <manifestEntries>
               <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>	
               <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+              <Automatic-Module-Name>ch.qos.reload4j</Automatic-Module-Name>
             </manifestEntries>
             <!-- Add to output produced by bundle-plugin -->
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
The current version of reload4j does not define any module name. That prevents adding it as a proper dependency in module descriptor. If you do, using the automatic module name based on the JAR file name (`reload4j`), the following warning is shown:

```
[WARNING] *******************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [reload4j-1.2.22.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] *******************************************************************************************************************************************
```

This PR sets an explicit automatic module name. Since all of reload4j's own dependencies are a) optional and b) have versions with proper module names, this allows module descriptors to use the new automatic module name (`ch.qos.reload4j`) without any warnings or other issues.