### PR TITLE
Replace log4j:WARN with reload4j:WARN

### DIFF
--- a/src/main/java/org/apache/log4j/Hierarchy.java
+++ b/src/main/java/org/apache/log4j/Hierarchy.java
@@ -126,7 +126,7 @@ public class Hierarchy implements LoggerRepository, RendererSupport, ThrowableRe
         if (!this.emittedNoAppenderWarning) {
             LogLog.warn("No appenders could be found for logger (" + cat.getName() + ").");
             LogLog.warn("Please initialize the log4j system properly.");
-            LogLog.warn("See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.");
+            LogLog.warn("See https://reload4j.qos.ch/faq.html#noconfig for more info.");
             this.emittedNoAppenderWarning = true;
         }
     }

--- a/src/main/java/org/apache/log4j/LogManager.java
+++ b/src/main/java/org/apache/log4j/LogManager.java
@@ -173,7 +173,7 @@ public class LogManager {
             repositorySelector = new DefaultRepositorySelector(new NOPLoggerRepository());
             guard = null;
             Exception ex = new IllegalStateException("Class invariant violation");
-            String msg = "log4j called after unloading, see http://logging.apache.org/log4j/1.2/faq.html#unload.";
+            String msg = "log4j called after unloading, see https://reload4j.qos.ch/faq.html#unload.";
             if (isLikelySafeScenario(ex)) {
                 LogLog.debug(msg, ex);
             } else {

--- a/src/main/java/org/apache/log4j/helpers/LogLog.java
+++ b/src/main/java/org/apache/log4j/helpers/LogLog.java
@@ -65,9 +65,9 @@ public class LogLog {
      */
     private static boolean quietMode = false;
 
-    private static final String PREFIX = "log4j: ";
-    private static final String ERR_PREFIX = "log4j:ERROR ";
-    private static final String WARN_PREFIX = "log4j:WARN ";
+    private static final String PREFIX = "reload4j: ";
+    private static final String ERR_PREFIX = "reload4j:ERROR ";
+    private static final String WARN_PREFIX = "reload4j:WARN ";
 
     static {
         String key = OptionConverter.getSystemProperty(DEBUG_KEY, null);

--- a/src/test/java/org/apache/log4j/xml/DOMTestCase.java
+++ b/src/test/java/org/apache/log4j/xml/DOMTestCase.java
@@ -131,9 +131,9 @@ public class DOMTestCase {
             System.setErr(sps);
             DOMConfigurator.configure(TEST_INPUT_PREFIX + "xml/DOMTest4.xml");
             common();
-            assertTrue(sps.stringList.get(0).contains("log4j:ERROR No appender named [A1] could be found."));
-            assertTrue(sps.stringList.get(1).contains("log4j:ERROR No appender named [A1] could be found."));
-            assertTrue(sps.stringList.get(2).contains("log4j:ERROR No appender named [A2] could be found."));
+            assertTrue(sps.stringList.get(0).contains("reload4j:ERROR No appender named [A1] could be found."));
+            assertTrue(sps.stringList.get(1).contains("reload4j:ERROR No appender named [A1] could be found."));
+            assertTrue(sps.stringList.get(2).contains("reload4j:ERROR No appender named [A2] could be found."));
         } finally {
             System.setErr(oldErr);
         }


### PR DESCRIPTION
Since the original `log4j:log4j` Maven artifact is still a quite common transitive dependency, an application might easily end up with both Log4j 1.2 and Reload4j.

The log messages used by Reload4j are identical to those generated by Log4j 1.2 and even point to the same documentation. This can confuse users that end up with multiple SLF4J backends in their runtime. I have seen multiple question on SO due to this, the most recent is [Why log4j can't find the configuration file](https://stackoverflow.com/questions/77260571/why-log4j-cant-find-the-configuration-file).

Changing the status logger prefix to "reload4j" and redirecting to https://reload4j.qos.ch/faq.html could save some debugging time to users.