### PR TITLE
Enables buddy class loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ch.qos.reload4j/reload4j/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ch.qos.reload4j/reload4j)
 [![CI Status](https://github.com/qos-ch/reload4j/workflows/CI/badge.svg?branch=master)](https://github.com/qos-ch/reload4j/actions?query=branch%3Amaster)
 

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,7 @@
             </Import-Package>
             <Bundle-DocURL>https://reload4j.qos.ch/</Bundle-DocURL>
             <Bundle-SymbolicName>org.apache.log4j</Bundle-SymbolicName>
+            <Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
Adds the buddy policy 'registered' to the
manifest so that custom appenders provided
by OSGi bundles can be loaded via buddy
class loading.

The providing bundle must define a
corresponding Eclipse-RegisterBuddy header.

Closes #72